### PR TITLE
Bulk of available transforms mechanism

### DIFF
--- a/decorator.js
+++ b/decorator.js
@@ -64,7 +64,7 @@ this.decorate = function(arrData){
 };
 
 //----====|| Get Options ||====----\\
-this.fnReturnOptions=function(objConfig){
+this.fnReturnOptions = function(objConfig) {
 	/*
 	this object is a subset of what is in suddenschema, it has a lot more values that can be ignored.
 	data types come from the library datatypetester https://github.com/SuddenDevelopment/dataTypeTester
@@ -75,22 +75,52 @@ this.fnReturnOptions=function(objConfig){
 		,max: 15
 	}
 	*/
+
 	//objConfig is expected to be an ovject with shce info filled in for a data field, probably from suddenschema
 	//the more data returned the narrower the results can be
-	var objResults={
-		 "ops":[]
-		,"acts":[]
+
+
+	var objConfigType = typeof objConfig;
+	if (!objConfigType || objConfigType !== 'object') {
+		objConfig = {};
+	}
+
+	var generalDataTypes = {
+		number: { ops: [], acts: [] },
+		string: { ops: [], acts: [] },
+		array: { ops: [], acts: [] },
+		object: { ops: [], acts: [] },
+		boolean: { ops: [], acts: [] },
 	};
-	//populate the operands that make sense
 
-	//populate the actions that make sense
+	var specificDataTypes = {
+		unixtime: { ops: [], acts: [] },
+		millitime: { ops: [], acts: [] },
+		ip: { ops: [], acts: [] },
+		email: { ops: [], acts: [] },
+		url: { ops: [], acts: [] },
+		domain: { ops: [], acts: [] },
+		image: { ops: [], acts: [] },
+		md5: { ops: [], acts: [] },
+		sha1: { ops: [], acts: [] },
+		sha256: { ops: [], acts: [] },
+		country_code: { ops: [], acts: [] }
+	};
 
-	//for now return ALL
-	objResults.ops=objOperands.keys;
-	objResults.acts=objActions.keys;
-
-	return objResults;
+	if (generalDataTypes[objConfig.targetType]) {
+		return generalDataTypes[objConfig.targetType];
+	}
+	else if (specificDataTypes[objConfig.targetType]) {
+		return specificDataTypes[objConfig.targetType];
+	}
+	else {
+		return {
+			ops: Object.keys(objOperands),
+			acts: Object.keys(objActions)
+		}
+	}
 };
+
 //----====|| Validate and Update Config ||====----\\
 this.fnUpdateConfig=function(objConfig){ 
 	//console.log('fnUpdateConfig',objConfig);

--- a/test/unit.js
+++ b/test/unit.js
@@ -43,13 +43,21 @@ describe('Available Transforms', function() {
         objResults.ops.should.be.an.Array;
         objResults.acts.should.be.an.Array;
 
+        objResults.ops.length.should.equal(expectedOperands.length);
+        objResults.acts.length.should.equal(expectedActions.length);
+
         checkArrayEquality(objResults.ops, expectedOperands);
         checkArrayEquality(objResults.acts, expectedActions);
     }
 
     function checkArrayEquality(arrGenerated, arrExpected) {
+
         arrExpected.forEach(function(item, index) {
             item.should.equal(arrGenerated[index]);
+        });
+
+        arrGenerated.forEach(function(item, index) {
+            item.should.equal(arrExpected[index]);
         });
     }
 
@@ -58,19 +66,17 @@ describe('Available Transforms', function() {
     it('returns all possible options in the absence of a config', function() {
         var objDec = new Decorator();
         var objTransformOptions = objDec.fnReturnOptions();
-        validateResultsObject(objTransformOptions, objDec.getAllAvailableOperands(), objDec.getAllAvailableActions());
+        objTransformOptions.should.be.an.Object;
+        should.exist(objTransformOptions.all);
+        validateResultsObject(objTransformOptions.all, objDec.getAllAvailableOperands(), objDec.getAllAvailableActions());
     });
 
     it('returns all possible options for configs that don\'t specify the data type field', function() {
         var objDec = new Decorator();
         var objTransformOptions = objDec.fnReturnOptions({ noTypeFieldIncluded: true });
-        validateResultsObject(objTransformOptions, objDec.getAllAvailableOperands(), objDec.getAllAvailableActions());
-    });
-
-    it('throws an exception for configs that specify an unrecognized data type', function() {
-        var objDec = new Decorator();
-        var strType = 'unrecognizedType'
-        objDec.fnReturnOptions.bind(objDec, { type: strType }).should.throw('Unrecognized data type: ' + strType);
+        objTransformOptions.should.be.an.Object;
+        should.exist(objTransformOptions.all);
+        validateResultsObject(objTransformOptions.all, objDec.getAllAvailableOperands(), objDec.getAllAvailableActions());
     });
 
     it('suppresses the loading of transform options at instantiation', function() {
@@ -79,29 +85,27 @@ describe('Available Transforms', function() {
     });
 
     it('triggers the loading of transform options at instantiation', function() {
-        var objDec1 = new Decorator({ filters: [], decorate: [] });
-        objDec1.getAllAvailableTransformOptions().should.be.an.Object;
+        var objDec1 = new Decorator({ filters: [], decorate: [] })
+          , objDec2 = new Decorator({ filters: [], decorate: [], suppressTransformOptionLoad: false });
 
-        var objDec2 = new Decorator({ filters: [], decorate: [], suppressTransformOptionLoad: false });
+        objDec1.getAllAvailableTransformOptions().should.be.an.Object;
         objDec2.getAllAvailableTransformOptions().should.be.an.Object;
     });
 
     it('gets options for the array data type in isolation', function() {
         var objDec = new Decorator({ filters: [], decorate: [], suppressTransformOptionLoad: true });
-
         var objTemplate = {
             array: { ops: ['in', 'has'], acts: ['implode'] }
         };
 
         objDec._loadTransformOptions(objTemplate)
 
-        var objTransformOptions = objDec.fnReturnOptions({ type: 'array' });
-        validateResultsObject(objTransformOptions, ['has', 'in'], ['implode', 'log']);
+        var objTransformOptions = objDec.fnReturnOptions({ typ: 'array' });
+        validateResultsObject(objTransformOptions.array, ['has', 'in'], ['implode', 'log']);
     });
 
     it('gets options for the ip data type which inherits from the string data type', function() {
         var objDec = new Decorator({ filters: [], decorate: [], suppressTransformOptionLoad: true });
-
         var objTemplate = {
             string: { ops: ['ne', 'eq'], acts: ['prepend', 'append'] },
             ip: { extends: 'string', ops: [], acts: [], excludesActions: ['prepend', 'log'] }
@@ -109,8 +113,8 @@ describe('Available Transforms', function() {
 
         objDec._loadTransformOptions(objTemplate)
 
-        var objTransformOptions = objDec.fnReturnOptions({ type: 'ip' });
-        validateResultsObject(objTransformOptions, ['eq', 'ne'], ['append']);
+        var objTransformOptions = objDec.fnReturnOptions({ typ: 'ip' });
+        validateResultsObject(objTransformOptions.ip, ['eq', 'ne'], ['append']);
     });
 
 });

--- a/test/unit.js
+++ b/test/unit.js
@@ -22,10 +22,78 @@ describe('simplest test', function () {
     ];
 
     var objBelt = new Decorator(objConfig);
-    var arrResults = objBelt.decorate(arrData); 
+    var arrResults = objBelt.decorate(arrData);
     //check
     console.log(arrResults);
    (arrResults[0].hobby).should.be.exactly('cats');
    done();
  });
+});
+
+describe('available transforms', function() {
+
+    //----====|| Helper Data ||====----\\
+    var allOperands = [
+        'any', 'find', 'empty', 'data', 'in', 'has', 'eq', 'ni', 'ne', 'gt', 'lt'
+    ]
+    .sort();
+
+    var allActions = [
+        'log', 'set', 'stack', 'unstack', 'add', 'copy', 'prepend', 'append', 'remove', 'rename',
+        'prioritize', 'focus', 'rand', 'implode', 'explode', 'findCopy'
+    ]
+    .sort();
+
+    //----====|| Helper Functions ||====----\\
+    function validateResultsObject(arrResults) {
+        arrResults.should.be.an.Object;
+
+        should.exist(arrResults.ops);
+        should.exist(arrResults.acts);
+
+        arrResults.ops.should.be.an.Array;
+        arrResults.acts.should.be.an.Array;
+
+        arrResults.ops.sort().forEach(function(item, index) {
+            item.should.equal(allOperands[index]);
+        });
+
+        arrResults.acts.sort().forEach(function(item, index) {
+            item.should.equal(allActions[index]);
+        });
+    }
+
+    function checkArrayEquality(arrGenerated, arrExpected) {
+        arrExpected.forEach(function(item, index) {
+            item.should.equal(arrGenerated[index]);
+        });
+    }
+
+
+    //----====|| TESTS ||====----\\
+
+    it('get all - no objConfig passed', function() {
+        var dec = new Decorator();
+        var arrResults = dec.fnReturnOptions();
+        validateResultsObject(arrResults);
+        checkArrayEquality(arrResults.ops.sort(), allOperands);
+        checkArrayEquality(arrResults.acts.sort(), allActions);
+    });
+
+    it('get all - bad config passed (no targetType field included)', function() {
+        var dec = new Decorator();
+        var arrResults = dec.fnReturnOptions({ noTargetTypeFieldIncluded: true });
+        validateResultsObject(arrResults);
+        checkArrayEquality(arrResults.ops.sort(), allOperands);
+        checkArrayEquality(arrResults.acts.sort(), allActions);
+    });
+
+    it('get all - unrecognized targetType', function() {
+        var dec = new Decorator();
+        var arrResults = dec.fnReturnOptions({ targetType: 'somethingYouDontEvenKnowAbout' });
+        validateResultsObject(arrResults);
+        checkArrayEquality(arrResults.ops.sort(), allOperands);
+        checkArrayEquality(arrResults.acts.sort(), allActions);
+    });
+
 });

--- a/test/unit.js
+++ b/test/unit.js
@@ -30,37 +30,21 @@ describe('simplest test', function () {
  });
 });
 
-describe('available transforms', function() {
-
-    //----====|| Helper Data ||====----\\
-    var allOperands = [
-        'any', 'find', 'empty', 'data', 'in', 'has', 'eq', 'ni', 'ne', 'gt', 'lt'
-    ]
-    .sort();
-
-    var allActions = [
-        'log', 'set', 'stack', 'unstack', 'add', 'copy', 'prepend', 'append', 'remove', 'rename',
-        'prioritize', 'focus', 'rand', 'implode', 'explode', 'findCopy'
-    ]
-    .sort();
+describe('Available Transforms', function() {
 
     //----====|| Helper Functions ||====----\\
-    function validateResultsObject(arrResults) {
-        arrResults.should.be.an.Object;
 
-        should.exist(arrResults.ops);
-        should.exist(arrResults.acts);
+    function validateResultsObject(objResults, expectedOperands, expectedActions) {
+        objResults.should.be.an.Object;
 
-        arrResults.ops.should.be.an.Array;
-        arrResults.acts.should.be.an.Array;
+        should.exist(objResults.ops);
+        should.exist(objResults.acts);
 
-        arrResults.ops.sort().forEach(function(item, index) {
-            item.should.equal(allOperands[index]);
-        });
+        objResults.ops.should.be.an.Array;
+        objResults.acts.should.be.an.Array;
 
-        arrResults.acts.sort().forEach(function(item, index) {
-            item.should.equal(allActions[index]);
-        });
+        checkArrayEquality(objResults.ops, expectedOperands);
+        checkArrayEquality(objResults.acts, expectedActions);
     }
 
     function checkArrayEquality(arrGenerated, arrExpected) {
@@ -69,33 +53,64 @@ describe('available transforms', function() {
         });
     }
 
-
     //----====|| TESTS ||====----\\
 
-    it('get all - no objDataTypeConfig passed', function() {
-        var dec = new Decorator();
-        var arrResults = dec.fnReturnOptions();
-        validateResultsObject(arrResults);
-        checkArrayEquality(arrResults.ops.sort(), allOperands);
-        checkArrayEquality(arrResults.acts.sort(), allActions);
+    it('returns all possible options in the absence of a config', function() {
+        var objDec = new Decorator();
+        var objTransformOptions = objDec.fnReturnOptions();
+        validateResultsObject(objTransformOptions, objDec.getAllAvailableOperands(), objDec.getAllAvailableActions());
     });
 
-    it('get all - bad objDataTypeConfig passed (no "type" field included)', function() {
-        var dec = new Decorator();
-        var arrResults = dec.fnReturnOptions({ noTypeFieldIncluded: true });
-        validateResultsObject(arrResults);
-        checkArrayEquality(arrResults.ops.sort(), allOperands);
-        checkArrayEquality(arrResults.acts.sort(), allActions);
+    it('returns all possible options for configs that don\'t specify the data type field', function() {
+        var objDec = new Decorator();
+        var objTransformOptions = objDec.fnReturnOptions({ noTypeFieldIncluded: true });
+        validateResultsObject(objTransformOptions, objDec.getAllAvailableOperands(), objDec.getAllAvailableActions());
     });
 
-    it('get all - unrecognized type', function() {
-        var dec = new Decorator();
-        var arrResults = dec.fnReturnOptions({ type: 'somethingYouDontEvenKnowAbout' });
-        validateResultsObject(arrResults);
-        checkArrayEquality(arrResults.ops.sort(), allOperands);
-        checkArrayEquality(arrResults.acts.sort(), allActions);
+    it('throws an exception for configs that specify an unrecognized data type', function() {
+        var objDec = new Decorator();
+        var strType = 'unrecognizedType'
+        objDec.fnReturnOptions.bind(objDec, { type: strType }).should.throw('Unrecognized data type: ' + strType);
     });
 
+    it('suppresses the loading of transform options at instantiation', function() {
+        var objDec = new Decorator({ filters: [], decorate: [], suppressTransformOptionLoad: true });
+        assert.equal(objDec.getAllAvailableTransformOptions(), null);
+    });
 
+    it('triggers the loading of transform options at instantiation', function() {
+        var objDec1 = new Decorator({ filters: [], decorate: [] });
+        objDec1.getAllAvailableTransformOptions().should.be.an.Object;
+
+        var objDec2 = new Decorator({ filters: [], decorate: [], suppressTransformOptionLoad: false });
+        objDec2.getAllAvailableTransformOptions().should.be.an.Object;
+    });
+
+    it('gets options for the array data type in isolation', function() {
+        var objDec = new Decorator({ filters: [], decorate: [], suppressTransformOptionLoad: true });
+
+        var objTemplate = {
+            array: { ops: ['in', 'has'], acts: ['implode'] }
+        };
+
+        objDec._loadTransformOptions(objTemplate)
+
+        var objTransformOptions = objDec.fnReturnOptions({ type: 'array' });
+        validateResultsObject(objTransformOptions, ['has', 'in'], ['implode', 'log']);
+    });
+
+    it('gets options for the ip data type which inherits from the string data type', function() {
+        var objDec = new Decorator({ filters: [], decorate: [], suppressTransformOptionLoad: true });
+
+        var objTemplate = {
+            string: { ops: ['ne', 'eq'], acts: ['prepend', 'append'] },
+            ip: { extends: 'string', ops: [], acts: [], excludesActions: ['prepend', 'log'] }
+        };
+
+        objDec._loadTransformOptions(objTemplate)
+
+        var objTransformOptions = objDec.fnReturnOptions({ type: 'ip' });
+        validateResultsObject(objTransformOptions, ['eq', 'ne'], ['append']);
+    });
 
 });

--- a/test/unit.js
+++ b/test/unit.js
@@ -95,26 +95,26 @@ describe('Available Transforms', function() {
     it('gets options for the array data type in isolation', function() {
         var objDec = new Decorator({ filters: [], decorate: [], suppressTransformOptionLoad: true });
         var objTemplate = {
-            array: { ops: ['in', 'has'], acts: ['implode'] }
+            array: { ops: ['find', 'in', 'ni'], acts: ['implode', 'stack', 'unstack'] }
         };
 
         objDec._loadTransformOptions(objTemplate)
 
         var objTransformOptions = objDec.fnReturnOptions({ typ: 'array' });
-        validateResultsObject(objTransformOptions.array, ['has', 'in'], ['implode', 'log']);
+        validateResultsObject(objTransformOptions.array, ['any', 'data', 'empty', 'find', 'in', 'ni'], ['copy', 'implode', 'log', 'set', 'stack', 'unstack']);
     });
 
     it('gets options for the ip data type which inherits from the string data type', function() {
         var objDec = new Decorator({ filters: [], decorate: [], suppressTransformOptionLoad: true });
         var objTemplate = {
             string: { ops: ['ne', 'eq'], acts: ['prepend', 'append'] },
-            ip: { extends: 'string', ops: [], acts: [], excludesActions: ['prepend', 'log'] }
+            ip: { extends: 'string', ops: [], acts: ['bigInt'], excludesActions: ['prepend', 'log'] }
         };
 
         objDec._loadTransformOptions(objTemplate)
 
         var objTransformOptions = objDec.fnReturnOptions({ typ: 'ip' });
-        validateResultsObject(objTransformOptions.ip, ['eq', 'ne'], ['append']);
+        validateResultsObject(objTransformOptions.ip, ['any', 'data', 'empty', 'eq', 'ne'], ['append', 'bigInt', 'copy', 'set']);
     });
 
 });

--- a/test/unit.js
+++ b/test/unit.js
@@ -72,7 +72,7 @@ describe('available transforms', function() {
 
     //----====|| TESTS ||====----\\
 
-    it('get all - no objConfig passed', function() {
+    it('get all - no objDataTypeConfig passed', function() {
         var dec = new Decorator();
         var arrResults = dec.fnReturnOptions();
         validateResultsObject(arrResults);
@@ -80,20 +80,22 @@ describe('available transforms', function() {
         checkArrayEquality(arrResults.acts.sort(), allActions);
     });
 
-    it('get all - bad config passed (no targetType field included)', function() {
+    it('get all - bad objDataTypeConfig passed (no "type" field included)', function() {
         var dec = new Decorator();
-        var arrResults = dec.fnReturnOptions({ noTargetTypeFieldIncluded: true });
+        var arrResults = dec.fnReturnOptions({ noTypeFieldIncluded: true });
         validateResultsObject(arrResults);
         checkArrayEquality(arrResults.ops.sort(), allOperands);
         checkArrayEquality(arrResults.acts.sort(), allActions);
     });
 
-    it('get all - unrecognized targetType', function() {
+    it('get all - unrecognized type', function() {
         var dec = new Decorator();
-        var arrResults = dec.fnReturnOptions({ targetType: 'somethingYouDontEvenKnowAbout' });
+        var arrResults = dec.fnReturnOptions({ type: 'somethingYouDontEvenKnowAbout' });
         validateResultsObject(arrResults);
         checkArrayEquality(arrResults.ops.sort(), allOperands);
         checkArrayEquality(arrResults.acts.sort(), allActions);
     });
+
+
 
 });


### PR DESCRIPTION
Issue: https://github.com/SuddenDevelopment/json-collection-decorator/issues/2

Allows for generating data type / option mappings, and retrieving these on an as-needed basis. Establishes a framework for specifying the operands and actions for base JavaScript data types, which can additionally be "extended" by more specific data types like `ip`, `url`, etc. There is also an "excludes" mechanism that allows the more specific data types to omit certain operands / actions of the base JavaScript data types from which they inherit.

Running the unit tests is the best way to observe the behavior: `node_modules/mocha/bin/mocha -R spec ./test`

(NOTE: the values in the `_objGlobalDataTypeOptions` and `_objDataTypeOptionsTemplate` variables should be reviewed and perhaps modified.)