### PR TITLE
Adds a unit test showing how to retrieve transform options for multiple data types

### DIFF
--- a/decorator.js
+++ b/decorator.js
@@ -225,6 +225,7 @@ self.fnReturnOptions = function(objDataTypeConfig) {
 };
 
 // Makes certain data accessible to client code. Currently, mostly used for comprehensive unit testing.
+self.loadTransformOptions = function(optionsTemplate) { self._loadTransformOptions(optionsTemplate); };
 self.getBaseOptionsTemplate = function() { return _objDataTypeOptionsTemplate; };
 self.getAllAvailableTransformOptions = function() { return _objTransformOptions; };
 self.getAllAvailableGlobalOptions = function() { return _objGlobalDataTypeOptions; };

--- a/test/unit.js
+++ b/test/unit.js
@@ -46,9 +46,6 @@ describe('Available Transforms', function() {
         objResults.ops.length.should.equal(expectedOperands.length);
         objResults.acts.length.should.equal(expectedActions.length);
 
-        console.log(objResults.ops);
-        console.log(objResults.acts);
-
         checkArrayEquality(objResults.ops, expectedOperands);
         checkArrayEquality(objResults.acts, expectedActions);
     }
@@ -101,10 +98,22 @@ describe('Available Transforms', function() {
             array: { ops: ['find', 'in', 'ni'], acts: ['implode', 'stack', 'unstack'] }
         };
 
-        objDec._loadTransformOptions(objTemplate)
+        /*
+        !!! OPTIONAL !!!
+        The loadTransformOptions() function allows for calling code to specify an options template, instead of using default definitions.
+        We only call loadTransformOptions() here in order to explicitly test the assembly of various transform options.
+        Unless calling code WANTS to define its own matrix of transform options, then loadTransformOptions() doesn't need to be called at all.
+        */
+        objDec.loadTransformOptions(objTemplate)
 
+        // Retrieve available transform options for the specified type, which in this case is just "array".
         var objTransformOptions = objDec.fnReturnOptions({ typ: 'array' });
-        validateResultsObject(objTransformOptions.array, ['any', 'data', 'empty', 'find', 'in', 'ni'], ['copy', 'implode', 'log', 'set', 'stack', 'unstack']);
+
+        // These are the operands and actions we expect to be returned for the specified types, which in this case is just "ip".
+        var arrExpectedOperandsForType_Array = ['any', 'data', 'empty', 'find', 'in', 'ni']
+          , arrExpectedActionsForType_Array = ['copy', 'implode', 'log', 'set', 'stack', 'unstack'];
+
+        validateResultsObject(objTransformOptions.array, arrExpectedOperandsForType_Array, arrExpectedActionsForType_Array);
     });
 
     it('gets options for the ip data type which inherits from the string data type', function() {
@@ -114,10 +123,63 @@ describe('Available Transforms', function() {
             ip: { extends: 'string', ops: [], acts: ['bigInt'], excludesActions: ['prepend', 'log'] }
         };
 
-        objDec._loadTransformOptions(objTemplate)
+        /*
+        !!! OPTIONAL !!!
+        The loadTransformOptions() function allows for calling code to specify an options template, instead of using default definitions.
+        We only call loadTransformOptions() here in order to explicitly test the assembly of various transform options.
+        Unless calling code WANTS to define its own matrix of transform options, then loadTransformOptions() doesn't need to be called at all.
+        */
+        objDec.loadTransformOptions(objTemplate)
 
+        // Retrieve available transform options for the specified type, which in this case is just "ip".
         var objTransformOptions = objDec.fnReturnOptions({ typ: 'ip' });
-        validateResultsObject(objTransformOptions.ip, ['any', 'data', 'empty', 'eq', 'ne'], ['append', 'bigInt', 'copy', 'set']);
+
+        // These are the operands and actions we expect to be returned for the specified types, which in this case is just "ip".
+        var arrExpectedOperandsForType_Ip = ['any', 'data', 'empty', 'eq', 'ne']
+          , arrExpectedActionsForType_Ip = ['append', 'bigInt', 'copy', 'set'];
+
+        validateResultsObject(objTransformOptions.ip, arrExpectedOperandsForType_Ip, arrExpectedActionsForType_Ip);
+    });
+
+    it('gets options for the multiple types', function() {
+        var objDec = new Decorator({ filters: [], decorate: [], suppressTransformOptionLoad: true });
+        var objTemplate = {
+            number: { ops: ['eq', 'ne', 'gt', 'lt'], acts: ['add'] }, // No options for this data type will be returned from fnReturnOptions(), since "number" is not present in any of the "type" fields in the object that's passed to fnReturnOptions()
+            string: { ops: ['eq', 'ne', 'in', 'ni'], acts: ['append', 'prepend', 'explode'] },
+            ip: { extends: 'string', ops: [], acts: ['bigInt'], excludesActions: ['prepend', 'log'] },
+            url: { extends: 'string', ops: [], acts: ['parse'], excludesActions: ['append', 'explode'] }
+        };
+
+        /*
+        !!! OPTIONAL !!!
+        The loadTransformOptions() function allows for calling code to specify an options template, instead of using default definitions.
+        We only call loadTransformOptions() here in order to explicitly test the assembly of various transform options.
+        Unless calling code WANTS to define its own matrix of transform options, then loadTransformOptions() doesn't need to be called at all.
+        */
+        objDec.loadTransformOptions(objTemplate)
+
+        // Retrieve available transform options for the specified types, which in this case includes: string, ip, url
+        var objTransformOptions = objDec.fnReturnOptions({ typ: 'string', dataTypes: ['ip', 'url'] });
+
+        // These are the operands and actions that we expect to be returned for the "string" data type.
+        var arrExpectedOperandsForType_String = ['any', 'data', 'empty', 'eq', 'in', 'ne', 'ni']
+          , arrExpectedActionsForType_String = ['append', 'copy', 'explode', 'log', 'prepend', 'set'];
+
+        // These are the operands and actions that we expect to be returned for the "ip" data type.
+        var arrExpectedOperandsForType_Ip = ['any', 'data', 'empty', 'eq', 'in', 'ne', 'ni']
+          , arrExpectedActionsForType_Ip = ['append', 'bigInt', 'copy', 'explode', 'set'];
+
+        // These are the operands and actions that we expect to be returned for the "url" data type.
+        var arrExpectedOperandsForType_Url = ['any', 'data', 'empty', 'eq', 'in', 'ne', 'ni']
+          , arrExpectedActionsForType_Url = ['copy', 'log', 'parse', 'prepend', 'set'];
+
+        /*
+        Options are returned for types "string", "ip", and "url"
+        ...since those types were declared in the "typ" and "dataTypes" fields in the argument object that was passed to fnReturnOptions() above
+        */
+        validateResultsObject(objTransformOptions.string, arrExpectedOperandsForType_String, arrExpectedActionsForType_String);
+        validateResultsObject(objTransformOptions.ip, arrExpectedOperandsForType_Ip, arrExpectedActionsForType_Ip);
+        validateResultsObject(objTransformOptions.url, arrExpectedOperandsForType_Url, arrExpectedActionsForType_Url);
     });
 
 });


### PR DESCRIPTION
I added comments related to this, but some important things to know are as follows.

--------

It is not necessary for calling code to call the `loadTransformOptions()` function. This should be called _only_ if the caller wants to override the default transform options that are generated by this library. The caller can override the generated mapping of available options at any time. If the caller does nothing to specify the options mapping, then the library will automatically generate the full mapping of available options based on the `_objGlobalDataTypeOptions` and `_objDataTypeOptionsTemplate` objects that are embedded within the library. This occurs automatically when the decorator object is instantiated.

--------

Whether the caller uses the default options mapping or specifies their own, every data type's options end up being composed of: 
- The "global" options that can apply to every data type (as specified in the `_objGlobalDataTypeOptions` object).
- If the data type "extends" another data type, then it inherits whatever its parent has set for `ops` and `acts`.
- The data type can have additional options defined just for it (e.g. the ip's `bigInt` action).
- The data type can explicitly exclude options by including array fields named `excludesOperands` and `excludesActions`.

(NOTE: All of the above can be (optionally) customized by the calling code (if desired) by calling `loadTransformOptions()` and providing it a mapping object. Overriding the global options is a little wonky, but doable, and in general shouldn't be an issue. The expectation is that in the vast majority of cases calling code will want to use the transform options mapping that is generated automatically by default.)

--------

When retrieving options for one or more data types...
...if, for example, you call `fnReturnOptions()` like this:

```var objTransformOptions = objDec.fnReturnOptions({ typ: 'string', dataTypes: ['ip', 'url'] });```

Then, the response you'd receive would look something like this:

```
{
  string: {ops: [...strings here...], acts: [...strings here...]},
  ip: {ops: [...strings here...], acts: [...strings here...]},
  url: {ops: [...strings here...], acts: [...strings here...]},
}
```
(Note: The contents of the `ops` and `acts` arrays for each data type get returned in alphabetical order.)



